### PR TITLE
Add example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.example` to `.env.local` and set the `GEMINI_API_KEY` to your Gemini API key
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- provide `.env.example` with a placeholder Gemini key
- update README to instruct copying the example to `.env.local`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842e7e0d1bc8327bbf9bae34e26efd7