### PR TITLE
Fix README and tissue icon bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,8 @@ used to communicate with Google Gemini.
 3. Start the proxy server in another terminal:
     `npm run proxy`
 4. Run the app for development:
-    `npm run dev`
-
    `npm run dev`
 
-codex/add-license-file-and-reference-in-readme
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
@@ -26,4 +23,3 @@ This project is licensed under the [MIT License](LICENSE).
 1. Build the static files: `npm run build`
 2. Serve the contents of `dist/` with any web server **and** run the proxy
    (`npm run proxy`) so that requests to `/api-proxy/` are forwarded to Gemini.
- main

--- a/components/icons/TissueIcon.tsx
+++ b/components/icons/TissueIcon.tsx
@@ -13,7 +13,7 @@ export const TissueIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
   >
     <path d="M20 6L8.27 6a4 4 0 00-3.95 3.08L3 14"></path>
     <path d="M4 18h14a2 2 0 002-2V8"></path>
-    <path d="M17 18a2 2 0 100-4h- период"></path> 
+  <path d="M17 18a2 2 0 0 0 0-4h-6"></path>
     <path d="M12 18v-4"></path>
     <path d="M6 18v-4"></path>
     <path d="M20 12.88V14a2 2 0 01-2 2H6.83"></path>


### PR DESCRIPTION
## Summary
- clean up duplicate/stray lines in README
- correct malformed SVG path in `TissueIcon`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842f20cf35c83279c691f959758159a